### PR TITLE
Support GCP WIF authentication

### DIFF
--- a/cloudid.js
+++ b/cloudid.js
@@ -1,6 +1,8 @@
 
 const AWS = require('aws-sdk')
 const aws4 = require('aws4')
+const fs = require('fs')
+const path = require('path')
 const { GoogleAuth } = require('google-auth-library');
 const { DefaultAzureCredential } = require("@azure/identity");
 
@@ -35,20 +37,54 @@ async function getGcpCloudID(audience) {
     }
 
     const googleAuth = new GoogleAuth();
-    const client = await googleAuth.getClient();
-    let token;
-
-    if (typeof client.fetchIdToken === 'function') {
-        token = await client.fetchIdToken(audience);
-    } else {
-        // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
-        // Use getIdTokenClient which handles all credential types including WIF.
+    try {
+        // Use getIdTokenClient for SA key, GCE metadata.
+        // For ExternalAccountClient (WIF), both fetchIdToken and getIdTokenClient
+        // throw "Cannot fetch ID token in this environment..." - fall back to IAM Credentials.
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
         const headers = await idTokenClient.getRequestHeaders();
-        token = headers.Authorization.replace('Bearer ', '');
+        const token = headers.Authorization.replace('Bearer ', '');
+        return Buffer.from(token).toString('base64');
+    } catch (err) {
+        const msg = err?.message || '';
+        if (!/cannot fetch id token/i.test(msg)) {
+            throw err;
+        }
+        // WIF fallback: use IAM Credentials API generateIdToken.
+        // Requires GOOGLE_APPLICATION_CREDENTIALS pointing to WIF config with
+        // service_account_impersonation_url.
+        return getGcpCloudIDViaIamCredentials(audience);
     }
+}
 
-    return Buffer.from(token).toString('base64')
+function extractServiceAccountFromCredFile(credPath) {
+    const json = JSON.parse(fs.readFileSync(credPath, 'utf8'));
+    const url = json.service_account_impersonation_url ||
+        json.service_account_impersonation?.url ||
+        json.service_account_impersonation?.token_url ||
+        '';
+    // URL format: .../projects/-/serviceAccounts/EMAIL@project.iam.gserviceaccount.com:generateAccessToken
+    const m = url.match(/\/serviceAccounts\/([^:]+)/);
+    return m ? `projects/-/serviceAccounts/${m[1]}` : null;
+}
+
+async function getGcpCloudIDViaIamCredentials(audience) {
+    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (!credPath || !fs.existsSync(credPath)) {
+        throw new Error('GOOGLE_APPLICATION_CREDENTIALS not set or file missing; cannot use IAM Credentials fallback');
+    }
+    const name = extractServiceAccountFromCredFile(credPath);
+    if (!name) {
+        throw new Error('Could not extract service account from credential file (no service_account_impersonation_url)');
+    }
+    const { IAMCredentialsClient } = require('@google-cloud/iam-credentials').v1;
+    const client = new IAMCredentialsClient();
+    const [response] = await client.generateIdToken({ name, audience, includeEmail: true });
+    const token = response.token;
+    if (!token) {
+        throw new Error('IAM Credentials generateIdToken returned empty token');
+    }
+    return Buffer.from(token).toString('base64');
 }
 
 function getAWsCloudId() {

--- a/cloudid.js
+++ b/cloudid.js
@@ -3,6 +3,7 @@ const AWS = require('aws-sdk')
 const aws4 = require('aws4')
 const { GoogleAuth } = require('google-auth-library');
 const { DefaultAzureCredential } = require("@azure/identity");
+const { IAMCredentialsClient } = require('@google-cloud/iam-credentials')
 
 async function getCloudId(acc_type, param) {
     if (acc_type === "aws_iam") {
@@ -39,21 +40,24 @@ async function getGcpCloudID(audience) {
     let token;
 
     if (typeof client.fetchIdToken === 'function') {
-        console.log('We handle OIDC: client.fetchIdToken is a function');
         token = await client.fetchIdToken(audience);
+    } else if (client.serviceAccountImpersonationUrl) {
+        // WIF with SA impersonation: getIdTokenClient throws. Use IAM Credentials API.
+        // URL format: .../v1/projects/-/serviceAccounts/EMAIL:generateAccessToken
+        // name for generateIdToken: projects/-/serviceAccounts/EMAIL
+        const url = client.serviceAccountImpersonationUrl;
+        const name = url.split('/v1/')[1]?.split(':')[0];
+        if (!name) throw new Error('Invalid serviceAccountImpersonationUrl format');
+        const [resp] = await new IAMCredentialsClient().generateIdToken({
+            name,
+            audience
+        });
+        token = resp.token;
     } else {
-        console.log('We handle WIF: client.getIdTokenClient is a function');
-        // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
-        // Use getIdTokenClient which handles all credential types including WIF.
-        console.log('getGcpCloudID: we get the audience: and client: ', audience, client);
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
-        console.log('getGcpCloudID: we get the idTokenClient: ', idTokenClient);
         const headers = await idTokenClient.getRequestHeaders();
-        console.log('getGcpCloudID: we get the headers: ', headers);
         token = headers.Authorization.replace('Bearer ', '');
-        console.log('getGcpCloudID: we get the token: ', token);
     }
-    console.log('getGcpCloudID:we get the token: ', token);
     return Buffer.from(token).toString('base64')
 }
 

--- a/cloudid.js
+++ b/cloudid.js
@@ -54,7 +54,7 @@ async function getGcpCloudID(audience) {
         });
         token = resp.token;
     } else {
-        // Get ID token via getIdTokenClient (JWT, GCE, Impersonated).
+        // Get ID token via getIdTokenClient (for google-auth-library clients types: JWT, GCE, Impersonated).
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
         const headers = await idTokenClient.getRequestHeaders();
         token = headers.Authorization.replace('Bearer ', '');

--- a/cloudid.js
+++ b/cloudid.js
@@ -45,6 +45,7 @@ async function getGcpCloudID(audience) {
         console.log('We handle WIF: client.getIdTokenClient is a function');
         // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
         // Use getIdTokenClient which handles all credential types including WIF.
+        console.log('getGcpCloudID: we get the audience: and client: ', audience, client);
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
         console.log('getGcpCloudID: we get the idTokenClient: ', idTokenClient);
         const headers = await idTokenClient.getRequestHeaders();

--- a/cloudid.js
+++ b/cloudid.js
@@ -1,8 +1,6 @@
 
 const AWS = require('aws-sdk')
 const aws4 = require('aws4')
-const fs = require('fs')
-const path = require('path')
 const { GoogleAuth } = require('google-auth-library');
 const { DefaultAzureCredential } = require("@azure/identity");
 
@@ -37,54 +35,20 @@ async function getGcpCloudID(audience) {
     }
 
     const googleAuth = new GoogleAuth();
-    try {
-        // Use getIdTokenClient for SA key, GCE metadata.
-        // For ExternalAccountClient (WIF), both fetchIdToken and getIdTokenClient
-        // throw "Cannot fetch ID token in this environment..." - fall back to IAM Credentials.
+    const client = await googleAuth.getClient();
+    let token;
+
+    if (typeof client.fetchIdToken === 'function') {
+        token = await client.fetchIdToken(audience);
+    } else {
+        // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
+        // Use getIdTokenClient which handles all credential types including WIF.
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
         const headers = await idTokenClient.getRequestHeaders();
-        const token = headers.Authorization.replace('Bearer ', '');
-        return Buffer.from(token).toString('base64');
-    } catch (err) {
-        const msg = err?.message || '';
-        if (!/cannot fetch id token/i.test(msg)) {
-            throw err;
-        }
-        // WIF fallback: use IAM Credentials API generateIdToken.
-        // Requires GOOGLE_APPLICATION_CREDENTIALS pointing to WIF config with
-        // service_account_impersonation_url.
-        return getGcpCloudIDViaIamCredentials(audience);
+        token = headers.Authorization.replace('Bearer ', '');
     }
-}
 
-function extractServiceAccountFromCredFile(credPath) {
-    const json = JSON.parse(fs.readFileSync(credPath, 'utf8'));
-    const url = json.service_account_impersonation_url ||
-        json.service_account_impersonation?.url ||
-        json.service_account_impersonation?.token_url ||
-        '';
-    // URL format: .../projects/-/serviceAccounts/EMAIL@project.iam.gserviceaccount.com:generateAccessToken
-    const m = url.match(/\/serviceAccounts\/([^:]+)/);
-    return m ? `projects/-/serviceAccounts/${m[1]}` : null;
-}
-
-async function getGcpCloudIDViaIamCredentials(audience) {
-    const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    if (!credPath || !fs.existsSync(credPath)) {
-        throw new Error('GOOGLE_APPLICATION_CREDENTIALS not set or file missing; cannot use IAM Credentials fallback');
-    }
-    const name = extractServiceAccountFromCredFile(credPath);
-    if (!name) {
-        throw new Error('Could not extract service account from credential file (no service_account_impersonation_url)');
-    }
-    const { IAMCredentialsClient } = require('@google-cloud/iam-credentials').v1;
-    const client = new IAMCredentialsClient();
-    const [response] = await client.generateIdToken({ name, audience, includeEmail: true });
-    const token = response.token;
-    if (!token) {
-        throw new Error('IAM Credentials generateIdToken returned empty token');
-    }
-    return Buffer.from(token).toString('base64');
+    return Buffer.from(token).toString('base64')
 }
 
 function getAWsCloudId() {

--- a/cloudid.js
+++ b/cloudid.js
@@ -36,11 +36,19 @@ async function getGcpCloudID(audience) {
 
     const googleAuth = new GoogleAuth();
     const client = await googleAuth.getClient();
-  
-    const token = await client.fetchIdToken(audience);
-    const res = Buffer.from(token).toString('base64')
+    let token;
 
-    return res
+    if (typeof client.fetchIdToken === 'function') {
+        token = await client.fetchIdToken(audience);
+    } else {
+        // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
+        // Use getIdTokenClient which handles all credential types including WIF.
+        const idTokenClient = await googleAuth.getIdTokenClient(audience);
+        const headers = await idTokenClient.getRequestHeaders();
+        token = headers.Authorization.replace('Bearer ', '');
+    }
+
+    return Buffer.from(token).toString('base64')
 }
 
 function getAWsCloudId() {

--- a/cloudid.js
+++ b/cloudid.js
@@ -42,11 +42,10 @@ async function getGcpCloudID(audience) {
     if (typeof client.fetchIdToken === 'function') {
         token = await client.fetchIdToken(audience);
     } else if (client.serviceAccountImpersonationUrl) {
-        // WIF with SA impersonation: getIdTokenClient throws. Use IAM Credentials API.
-        // URL format: .../v1/projects/-/serviceAccounts/EMAIL:generateAccessToken
-        // name for generateIdToken: projects/-/serviceAccounts/EMAIL
+        // WIF: get ID token via IAM Credentials API.
+        // URL format: https://iamcredentials.googleapis.com/v1/{name=projects/*/serviceAccounts/*}:generateAccessToken
         const url = client.serviceAccountImpersonationUrl;
-        const name = url.split('/v1/')[1]?.split(':')[0];
+        const name = url.match(/projects\/[^:]+/)?.[0];
         if (!name) throw new Error('Invalid serviceAccountImpersonationUrl format');
         const [resp] = await new IAMCredentialsClient().generateIdToken({
             name,
@@ -55,6 +54,7 @@ async function getGcpCloudID(audience) {
         });
         token = resp.token;
     } else {
+        // Get ID token via getIdTokenClient (JWT, GCE, Impersonated).
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
         const headers = await idTokenClient.getRequestHeaders();
         token = headers.Authorization.replace('Bearer ', '');

--- a/cloudid.js
+++ b/cloudid.js
@@ -50,7 +50,8 @@ async function getGcpCloudID(audience) {
         if (!name) throw new Error('Invalid serviceAccountImpersonationUrl format');
         const [resp] = await new IAMCredentialsClient().generateIdToken({
             name,
-            audience
+            audience,
+            includeEmail: true
         });
         token = resp.token;
     } else {

--- a/cloudid.js
+++ b/cloudid.js
@@ -39,15 +39,20 @@ async function getGcpCloudID(audience) {
     let token;
 
     if (typeof client.fetchIdToken === 'function') {
+        console.log('We handle OIDC: client.fetchIdToken is a function');
         token = await client.fetchIdToken(audience);
     } else {
+        console.log('We handle WIF: client.getIdTokenClient is a function');
         // Client types like ExternalAccountClient (WIF) don't implement fetchIdToken.
         // Use getIdTokenClient which handles all credential types including WIF.
         const idTokenClient = await googleAuth.getIdTokenClient(audience);
+        console.log('getGcpCloudID: we get the idTokenClient: ', idTokenClient);
         const headers = await idTokenClient.getRequestHeaders();
+        console.log('getGcpCloudID: we get the headers: ', headers);
         token = headers.Authorization.replace('Bearer ', '');
+        console.log('getGcpCloudID: we get the token: ', token);
     }
-
+    console.log('getGcpCloudID:we get the token: ', token);
     return Buffer.from(token).toString('base64')
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akeyless-cloud-id",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "",
   "main": "cloudid.js",
   "scripts": {

--- a/test_gcp_auth.js
+++ b/test_gcp_auth.js
@@ -19,12 +19,8 @@ const { getCloudId } = require('./cloudid');
 
 async function testGcpAuthentication() {
   try {
-    const token1 = await getCloudId('gcp', 'akeyless.io');
-    if (!token1 || token1.length === 0) throw new Error('Expected non-empty cloud ID');
-
-    const token2 = await getCloudId('gcp', 'https://example.com');
-    if (!token2 || token2.length === 0) throw new Error('Expected non-empty cloud ID');
-
+    const token = await getCloudId('gcp', 'akeyless.io');
+    if (!token || token.length === 0) throw new Error('Expected non-empty token');
     console.log('All GCP auth tests passed');
     return true;
   } catch (err) {

--- a/test_gcp_auth.js
+++ b/test_gcp_auth.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Test script for GCP IAM authentication.
+ *
+ * Tests getCloudId('gcp', audience) with:
+ * - Service account JSON (via GOOGLE_APPLICATION_CREDENTIALS)
+ * - GCE metadata server (when running on GCE instance)
+ * - Application Default Credentials
+ *
+ * Usage:
+ *   export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
+ *   node test_gcp_auth.js
+ *
+ *   # Or on GCE instance (no env var needed):
+ *   node test_gcp_auth.js
+ */
+
+const { getCloudId } = require('./cloudid');
+
+async function testGcpAuthentication() {
+  try {
+    const token1 = await getCloudId('gcp', 'akeyless.io');
+    if (!token1 || token1.length === 0) throw new Error('Expected non-empty cloud ID');
+
+    const token2 = await getCloudId('gcp', 'https://example.com');
+    if (!token2 || token2.length === 0) throw new Error('Expected non-empty cloud ID');
+
+    console.log('All GCP auth tests passed');
+    return true;
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    console.error('Troubleshooting: Set GOOGLE_APPLICATION_CREDENTIALS or run on GCE');
+    return false;
+  }
+}
+
+testGcpAuthentication().then((success) => {
+  process.exit(success ? 0 : 1);
+});


### PR DESCRIPTION
Add support for WIF by using the IAM Credentials API when the client does not support fetchIdToken.


**Problem**
When running in environments that use GCP Workload Identity Federation (with GitHub), credentials use serviceAccountImpersonationUrl instead of service account keys. google-auth-library clients in this setup do not expose fetchIdToken, so authentication with Akeyless fails. This affects workflows like self-hosted runners on GKE or GitHub Actions with GCP WIF.

**Solution**
Add a fallback chain for GCP cloud-ID:
1. Preferred: Use fetchIdToken when the client supports it (service account keys, some metadata).
2. WIF: If the client has serviceAccountImpersonationUrl (WIF / impersonated credentials), call the IAM Credentials  
    API generateIdToken to obtain an ID token.
3. Other: Fallback to getIdTokenClient(audience) for JWT, GCE, and impersonated clients that don’t support  
    fetchIdToken directly.

**Technical details**
- Uses @google-cloud/iam-credentials for the WIF path.
- Extracts the impersonated service account name from serviceAccountImpersonationUrl to call generateIdToken.
- Adds includeEmail: true for compatibility with Akeyless expectations.

**Testing**
1. Verified with GitHub Actions workflow using GCP WIF (impersonated service account).
2. test_gcp_auth.js workflow provides a manual integration test (under akeyless-github-action).

**Compatibility**
1. No change in existing behavior – The new WIF path runs only when client.serviceAccountImpersonationUrl is set. All other credential types (service account keys, GCE metadata, etc.) still use the same code paths as before.
2. Adds dependency: @google-cloud/iam-credentials.

**Related**
1. Fixes GCP WIF auth in environments such as [akeyless-github-action](https://github.com/akeylesslabs/akeyless-github-action) when using GCP Workload Identity Federation with GitHub.
2. Ticket: ASM-17037
