### PR TITLE
test: add hermetic unit suite + CI pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: "Tests"
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  js-test:
+    name: JS Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Pinned to Node 20 LTS: a transitive dependency (buffer-equal-constant-time,
+          # pulled in via google-auth-library@7 -> jws/jwa) relies on Buffer.SlowBuffer,
+          # which was removed in Node 24+. The SDK cannot be required on newer runtimes
+          # until that dependency chain is upgraded.
+          node-version: "20"
+
+      # NOTE: `npm ci` currently fails against this repo's lockfile (known drift;
+      # see PR #32). Using `npm install` until the lockfile fix lands on the
+      # default branch, after which this can switch back to `npm ci`.
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/cloudid.e2e.test.js
+++ b/cloudid.e2e.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+/**
+ * Credentials-gated LIVE end-to-end test.
+ *
+ * This test talks to a real cloud provider and is therefore SKIPPED by default
+ * so CI never fails when no secrets are configured. To run it, export:
+ *
+ *   AKEYLESS_CLOUD_ID_E2E=1
+ *   AKEYLESS_CLOUD_ID_E2E_TYPE=aws_iam|azure_ad|gcp   (default: aws_iam)
+ *   AKEYLESS_CLOUD_ID_E2E_PARAM=<object-id | audience> (optional, provider-specific)
+ *
+ * plus whatever ambient credentials that provider needs (e.g. AWS_* env vars /
+ * instance role, GOOGLE_APPLICATION_CREDENTIALS, Azure managed identity, ...).
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { getCloudId } = require('./cloudid');
+
+const enabled = process.env.AKEYLESS_CLOUD_ID_E2E === '1';
+const type = process.env.AKEYLESS_CLOUD_ID_E2E_TYPE || 'aws_iam';
+const param = process.env.AKEYLESS_CLOUD_ID_E2E_PARAM;
+
+test(
+  `live e2e: getCloudId('${type}') returns a non-empty token`,
+  { skip: enabled ? false : 'set AKEYLESS_CLOUD_ID_E2E=1 (and provider credentials) to run' },
+  async () => {
+    const token = await getCloudId(type, param);
+    assert.strictEqual(typeof token, 'string', 'token should be a string');
+    assert.ok(token.length > 0, 'token should be non-empty');
+  }
+);

--- a/cloudid.test.js
+++ b/cloudid.test.js
@@ -1,0 +1,316 @@
+'use strict';
+
+/**
+ * Hermetic unit tests for the akeyless-cloud-id SDK (cloudid.js).
+ *
+ * These tests run fully offline. Before requiring the SDK (and, transitively,
+ * aws-sdk / google-auth-library / @azure/identity) we:
+ *   - point HOME and the AWS credential/config files at an empty temp dir so no
+ *     ambient ~/.aws credentials or profiles can leak in,
+ *   - disable the EC2 instance-metadata provider,
+ *   - clear any AWS_* credential env vars,
+ *   - install a network guard that throws if any TCP socket connect is attempted.
+ *
+ * The AWS cloud-id path is pure crypto (aws4 SigV4 signing) once credentials are
+ * resolved from the environment, so it produces a deterministic token with no
+ * network access.
+ */
+
+const { test, describe, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const net = require('node:net');
+
+// ---------------------------------------------------------------------------
+// Hermetic isolation — MUST happen before requiring the SDK / provider libs.
+// ---------------------------------------------------------------------------
+const isoHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cloudid-test-home-'));
+const isoCreds = path.join(isoHome, 'credentials');
+const isoConfig = path.join(isoHome, 'config');
+// Empty (but existing) files: no profiles/keys inside, so nothing leaks in, yet
+// aws-sdk can still stat/read them without raising ENOENT.
+fs.writeFileSync(isoCreds, '');
+fs.writeFileSync(isoConfig, '');
+process.env.HOME = isoHome;
+process.env.USERPROFILE = isoHome; // Windows equivalent
+process.env.AWS_SHARED_CREDENTIALS_FILE = isoCreds;
+process.env.AWS_CONFIG_FILE = isoConfig;
+process.env.AWS_EC2_METADATA_DISABLED = 'true';
+// NOTE: do NOT set AWS_SDK_LOAD_CONFIG here — aws-sdk treats any non-empty value
+// (even "0") as enabled, which would force-load the config file.
+delete process.env.AWS_SDK_LOAD_CONFIG;
+delete process.env.AWS_ACCESS_KEY_ID;
+delete process.env.AWS_SECRET_ACCESS_KEY;
+delete process.env.AWS_SESSION_TOKEN;
+delete process.env.AWS_PROFILE;
+
+// Network guard: any attempt to open a real TCP socket during the guarded
+// window throws, proving the code path did not touch the network.
+const realConnect = net.Socket.prototype.connect;
+let networkBlocked = false;
+net.Socket.prototype.connect = function guardedConnect(...args) {
+  if (networkBlocked) {
+    const err = new Error('NETGUARD: TCP socket connect attempted during hermetic test');
+    err.netguard = true;
+    throw err;
+  }
+  return realConnect.apply(this, args);
+};
+
+const AWS = require('aws-sdk');
+const cloudid = require('./cloudid');
+
+// Well-formed but fake credentials (AWS docs example key id + secret).
+const FAKE_ACCESS_KEY = 'AKIDEXAMPLE';
+const FAKE_SECRET_KEY = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+const FAKE_SESSION_TOKEN = 'FQoGZXIvYXdzEXAMPLESESSIONTOKEN//////////fake';
+
+function setEnvCreds({ session } = {}) {
+  process.env.AWS_ACCESS_KEY_ID = FAKE_ACCESS_KEY;
+  process.env.AWS_SECRET_ACCESS_KEY = FAKE_SECRET_KEY;
+  if (session) {
+    process.env.AWS_SESSION_TOKEN = FAKE_SESSION_TOKEN;
+  } else {
+    delete process.env.AWS_SESSION_TOKEN;
+  }
+  // Force aws-sdk to re-resolve credentials from the (updated) environment.
+  AWS.config.credentials = null;
+}
+
+function clearEnvCreds() {
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.AWS_SESSION_TOKEN;
+  AWS.config.credentials = null;
+}
+
+// Decode the base64(JSON) cloud-id token into its outer object and the inner
+// (also base64-encoded) STS request headers.
+function decodeToken(token) {
+  assert.strictEqual(typeof token, 'string', 'token should be a string');
+  const outer = JSON.parse(Buffer.from(token, 'base64').toString('utf8'));
+  const headers = JSON.parse(
+    Buffer.from(outer.sts_request_headers, 'base64').toString('utf8')
+  );
+  return { outer, headers };
+}
+
+after(() => {
+  net.Socket.prototype.connect = realConnect;
+  try { fs.rmSync(isoHome, { recursive: true, force: true }); } catch (_) {}
+});
+
+// ---------------------------------------------------------------------------
+describe('module loads and exports are intact', () => {
+  test('exports the documented public API as functions', () => {
+    for (const name of ['getCloudId', 'getAWsCloudId', 'getAzureCloudID', 'getGcpCloudID']) {
+      assert.strictEqual(typeof cloudid[name], 'function', `${name} should be a function`);
+    }
+  });
+
+  test('does not export unexpected extra symbols', () => {
+    assert.deepStrictEqual(
+      Object.keys(cloudid).sort(),
+      ['getAWsCloudId', 'getAzureCloudID', 'getCloudId', 'getGcpCloudID']
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('getCloudId provider dispatch', () => {
+  beforeEach(() => clearEnvCreds());
+
+  test('access_key type resolves to an empty string (no cloud-id needed)', async () => {
+    const result = await cloudid.getCloudId('access_key');
+    assert.strictEqual(result, '');
+  });
+
+  test('unknown access type rejects with "Invalid access type"', async () => {
+    await assert.rejects(
+      () => cloudid.getCloudId('not_a_real_type'),
+      /Invalid access type/
+    );
+  });
+
+  test('undefined access type rejects with "Invalid access type"', async () => {
+    await assert.rejects(
+      () => cloudid.getCloudId(),
+      /Invalid access type/
+    );
+  });
+
+  test('aws_iam type dispatches to the AWS path and yields a valid STS token', async () => {
+    setEnvCreds({ session: true });
+    networkBlocked = true;
+    try {
+      const token = await cloudid.getCloudId('aws_iam');
+      const { outer } = decodeToken(token);
+      assert.strictEqual(
+        Buffer.from(outer.sts_request_url, 'base64').toString('utf8'),
+        'https://sts.amazonaws.com/'
+      );
+    } finally {
+      networkBlocked = false;
+    }
+  });
+
+  test('azure_ad type dispatches to the Azure provider (not the invalid-type branch)', async () => {
+    // Offline: DefaultAzureCredential reports "credential unavailable" without
+    // any network. We only assert that dispatch entered the Azure branch, i.e.
+    // it did NOT fall through to the generic "Invalid access type" error.
+    networkBlocked = true;
+    try {
+      await assert.rejects(
+        () => cloudid.getCloudId('azure_ad', 'object-id'),
+        (err) => {
+          assert.doesNotMatch(err.message, /Invalid access type/);
+          return true;
+        }
+      );
+    } finally {
+      networkBlocked = false;
+    }
+  });
+
+  test('gcp type dispatches to the GCP provider (not the invalid-type branch)', async () => {
+    // Offline: with the network guard armed, the GCP metadata lookup is blocked
+    // and the client rejects with a credentials error. We assert only that
+    // dispatch entered the GCP branch, never that a live token was produced.
+    networkBlocked = true;
+    try {
+      await assert.rejects(
+        () => cloudid.getCloudId('gcp', 'akeyless.io'),
+        (err) => {
+          assert.doesNotMatch(err.message, /Invalid access type/);
+          return true;
+        }
+      );
+    } finally {
+      networkBlocked = false;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('AWS cloud-id token construction (offline SigV4)', () => {
+  beforeEach(() => clearEnvCreds());
+
+  test('produces a base64(JSON) token wrapping a signed STS GetCallerIdentity request', async () => {
+    setEnvCreds({ session: true });
+    networkBlocked = true;
+    let token;
+    try {
+      token = await cloudid.getAWsCloudId();
+    } finally {
+      networkBlocked = false;
+    }
+    const { outer, headers } = decodeToken(token);
+
+    // Outer envelope shape.
+    assert.deepStrictEqual(
+      Object.keys(outer).sort(),
+      ['sts_request_body', 'sts_request_headers', 'sts_request_method', 'sts_request_url']
+    );
+    assert.strictEqual(outer.sts_request_method, 'POST');
+    assert.strictEqual(
+      Buffer.from(outer.sts_request_url, 'base64').toString('utf8'),
+      'https://sts.amazonaws.com/'
+    );
+    assert.strictEqual(
+      Buffer.from(outer.sts_request_body, 'base64').toString('utf8'),
+      'Action=GetCallerIdentity&Version=2011-06-15'
+    );
+  });
+
+  test('signs the request with SigV4 (Authorization: AWS4-HMAC-SHA256) and X-Amz-Date', async () => {
+    setEnvCreds({ session: true });
+    networkBlocked = true;
+    let token;
+    try {
+      token = await cloudid.getAWsCloudId();
+    } finally {
+      networkBlocked = false;
+    }
+    const { headers } = decodeToken(token);
+
+    assert.ok(Array.isArray(headers.Authorization), 'Authorization header should be an array');
+    const authz = headers.Authorization[0];
+    assert.match(authz, /^AWS4-HMAC-SHA256 /);
+    assert.match(authz, new RegExp(`Credential=${FAKE_ACCESS_KEY}/\\d{8}/us-east-1/sts/aws4_request`));
+    assert.match(authz, /SignedHeaders=[^,]*x-amz-date/);
+    assert.match(authz, /Signature=[0-9a-f]{64}/);
+
+    assert.ok(Array.isArray(headers['X-Amz-Date']));
+    assert.match(headers['X-Amz-Date'][0], /^\d{8}T\d{6}Z$/);
+
+    // Host targets the global STS endpoint.
+    assert.strictEqual(headers.Host[0], 'sts.amazonaws.com');
+    assert.match(headers['Content-Type'][0], /application\/x-www-form-urlencoded/);
+  });
+
+  test('includes X-Amz-Security-Token when a session token is present', async () => {
+    setEnvCreds({ session: true });
+    networkBlocked = true;
+    let token;
+    try {
+      token = await cloudid.getAWsCloudId();
+    } finally {
+      networkBlocked = false;
+    }
+    const { headers } = decodeToken(token);
+    assert.ok(Array.isArray(headers['X-Amz-Security-Token']), 'security token header present');
+    assert.strictEqual(headers['X-Amz-Security-Token'][0], FAKE_SESSION_TOKEN);
+    // The session token is also folded into the SigV4 SignedHeaders list.
+    assert.match(headers.Authorization[0], /SignedHeaders=[^,]*x-amz-security-token/);
+  });
+
+  test('omits X-Amz-Security-Token for static (long-term) credentials', async () => {
+    setEnvCreds({ session: false });
+    networkBlocked = true;
+    let token;
+    try {
+      token = await cloudid.getAWsCloudId();
+    } finally {
+      networkBlocked = false;
+    }
+    const { headers } = decodeToken(token);
+    assert.strictEqual(headers['X-Amz-Security-Token'], undefined);
+    // Still a valid SigV4 signature, just without the session-token signed header.
+    assert.match(headers.Authorization[0], /^AWS4-HMAC-SHA256 /);
+    assert.doesNotMatch(headers.Authorization[0], /x-amz-security-token/);
+  });
+
+  test('rejects when no credentials can be resolved from any provider', async () => {
+    clearEnvCreds();
+    networkBlocked = true;
+    try {
+      await assert.rejects(
+        () => cloudid.getAWsCloudId(),
+        (err) => {
+          // aws-sdk raises a CredentialsError; must not be our net guard firing.
+          assert.ok(!err.netguard, 'no network should be attempted while resolving creds');
+          assert.match(String(err.code || err.name || err.message), /Credentials/i);
+          return true;
+        }
+      );
+    } finally {
+      networkBlocked = false;
+    }
+  });
+
+  test('two invocations with the same credentials are deterministic in shape', async () => {
+    setEnvCreds({ session: true });
+    networkBlocked = true;
+    try {
+      const a = decodeToken(await cloudid.getAWsCloudId());
+      const b = decodeToken(await cloudid.getAWsCloudId());
+      assert.deepStrictEqual(Object.keys(a.outer).sort(), Object.keys(b.outer).sort());
+      assert.strictEqual(a.outer.sts_request_url, b.outer.sts_request_url);
+      assert.strictEqual(a.outer.sts_request_body, b.outer.sts_request_body);
+    } finally {
+      networkBlocked = false;
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "cloudid.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

This repo previously had **no test suite** (`npm test` was the placeholder error) and only a CodeQL workflow. This PR adds a comprehensive, fully **hermetic** unit test suite plus a GitHub Actions **Tests** pipeline.

## Tests added

**`cloudid.test.js`** — offline unit tests (`node:test` + `node:assert`), no network sockets, fake credentials, isolated `HOME`/AWS config so nothing leaks in. A network guard throws on any TCP `connect` during the guarded window to *prove* the AWS path is offline.

- **Module + exports**
  - public API (`getCloudId`, `getAWsCloudId`, `getAzureCloudID`, `getGcpCloudID`) are functions
  - no unexpected extra exports
- **Provider dispatch (`getCloudId`)**
  - `access_key` resolves to `""`
  - unknown type rejects with `Invalid access type`
  - `undefined` type rejects with `Invalid access type`
  - `aws_iam` dispatches to the AWS path and yields a valid STS token
  - `azure_ad` dispatches into the Azure branch (not the invalid-type branch)
  - `gcp` dispatches into the GCP branch (not the invalid-type branch)
- **AWS cloud-id construction (offline SigV4)**
  - token is `base64(JSON)` wrapping a signed STS `GetCallerIdentity` request (`POST`, `https://sts.amazonaws.com/`, correct body)
  - `Authorization: AWS4-HMAC-SHA256` with `Credential=.../us-east-1/sts/aws4_request`, `SignedHeaders`, 64-hex `Signature`, and a well-formed `X-Amz-Date`
  - `X-Amz-Security-Token` present (and signed) when a session token is supplied
  - `X-Amz-Security-Token` omitted for static long-term credentials
  - rejects with a `CredentialsError` when no credentials resolve — no network attempted
  - token shape is deterministic across repeated invocations

**`cloudid.e2e.test.js`** — a **credentials-gated live e2e** test. Skipped by default so CI never fails without secrets. Enable with `AKEYLESS_CLOUD_ID_E2E=1` (plus `AKEYLESS_CLOUD_ID_E2E_TYPE` / `AKEYLESS_CLOUD_ID_E2E_PARAM` and the relevant provider credentials).

> Per guidance, GCP/Azure are covered only by offline-provable dispatch/validation — no assertions against live GCP/Azure services in the unit suite.

## CI added

`.github/workflows/test.yml` (`name: "Tests"`, modeled on go-cloud-id's `test.yml`): triggers on push to all branches + pull_request; steps = checkout → setup-node → install deps → `npm test`.

- `package.json` `"test"` is now `node --test`.
- **Node version pinned to 20 LTS.** A transitive dependency (`buffer-equal-constant-time` via `google-auth-library@7` → `jws`/`jwa`) relies on `Buffer.SlowBuffer`, which was **removed in Node 24+**, so the SDK cannot even be `require()`d on newer runtimes until that dependency chain is upgraded.
- CI uses `npm install` (not `npm ci`): `npm ci` fails against the current lockfile on the default branch (known drift; the fix is in flight in PR #32). Switch back to `npm ci` once that lands.

## Local `npm test` result (Node 20)

```
# tests 15
# suites 3
# pass 14
# fail 0
# skipped 1   (credentials-gated e2e)
```

All 14 hermetic tests pass; the live e2e is skipped as designed.

## Notes for reviewer
- Does not touch `cloudid.js` production code or the lockfile (left for PR #32).
- Heads-up: Dependabot reports 62 vulnerabilities on the default branch — out of scope here, but the pinned-to-Node-20 constraint above is a symptom of the same stale dependency tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive offline tests for cloud identity behavior, including provider handling, credential errors, token generation, and request signing.
  * Added an optional live end-to-end test for cloud identity retrieval using configured credentials.

* **Chores**
  * Enabled the standard test command using Node’s built-in test runner.
  * Added automated test execution for pushes and pull requests through GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->